### PR TITLE
Adds multi-card support

### DIFF
--- a/model_utils.py
+++ b/model_utils.py
@@ -5,7 +5,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=None, auth_token=None):    
+def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=None, auth_token=None, device_map=None):    
     if model_name.startswith('Salesforce/codegen'):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         if model_path is not None:
@@ -118,10 +118,10 @@ def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=Non
     elif model_path is not None and model_path != "":
         logger.warning("model_path is not None, but model_name is not given. Load from model_path only")
         tokenizer = AutoTokenizer.from_pretrained(model_path, use_auth_token=auth_token)
-        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float16, use_auth_token=auth_token)
+        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float16, use_auth_token=auth_token, device_map=device_map)
     else:
         tokenizer = AutoTokenizer.from_pretrained(model_name, use_auth_token=auth_token)
-        model = AutoModelForCausalLM.from_pretrained(model_name, use_auth_token=auth_token)
+        model = AutoModelForCausalLM.from_pretrained(model_name, use_auth_token=auth_token, device_map=device_map)
 
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token

--- a/model_utils.py
+++ b/model_utils.py
@@ -1,11 +1,38 @@
 import torch
 from transformers import AutoModelForCausalLM, T5Tokenizer, T5ForConditionalGeneration, AutoModelForSeq2SeqLM
 from transformers import AutoConfig, AutoTokenizer, OPTForCausalLM
+from accelerate import init_empty_weights, infer_auto_device_map
 import logging
 
 logger = logging.getLogger(__name__)
 
-def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=None, auth_token=None, device_map=None, trust_remote_code=False, return_token_type_ids=None):    
+def get_local_huggingface_tokenizer_model(
+        model_name, 
+        model_path=None, 
+        dtype=None, 
+        auth_token=None, 
+        max_memory=None, 
+        trust_remote_code=False, 
+        return_token_type_ids=None, 
+        device=None
+): 
+    if max_memory != {}:
+        config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)
+        # load empty weights
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_config(config, trust_remote_code=trust_remote_code)
+        model.tie_weights()
+            
+        #create a device_map from max_memory
+        device_map = infer_auto_device_map(
+            model,
+            max_memory=max_memory,
+            no_split_module_classes=["GPTNeoXLayer", "DecoderLayer"],
+            dtype=dtype,
+        )
+    else:
+        device_map = None
+
     if model_name.startswith('Salesforce/codegen'):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         if model_path is not None:
@@ -127,6 +154,10 @@ def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=Non
         tokenizer.pad_token = tokenizer.eos_token
     tokenizer.padding_side = 'left'
     tokenizer.truncation_side = 'left'
+
+    if max_memory == {}:
+        model = model.to(device)
+
     return model, tokenizer
 
 

--- a/model_utils.py
+++ b/model_utils.py
@@ -5,7 +5,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=None, auth_token=None, device_map=None):    
+def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=None, auth_token=None, device_map=None, trust_remote_code=False):    
     if model_name.startswith('Salesforce/codegen'):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         if model_path is not None:
@@ -118,10 +118,10 @@ def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=Non
     elif model_path is not None and model_path != "":
         logger.warning("model_path is not None, but model_name is not given. Load from model_path only")
         tokenizer = AutoTokenizer.from_pretrained(model_path, use_auth_token=auth_token)
-        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float16, use_auth_token=auth_token, device_map=device_map)
+        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float16, use_auth_token=auth_token, device_map=device_map, trust_remote_code=trust_remote_code)
     else:
         tokenizer = AutoTokenizer.from_pretrained(model_name, use_auth_token=auth_token)
-        model = AutoModelForCausalLM.from_pretrained(model_name, use_auth_token=auth_token, device_map=device_map)
+        model = AutoModelForCausalLM.from_pretrained(model_name, use_auth_token=auth_token, device_map=device_map, trust_remote_code=trust_remote_code)
 
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token

--- a/model_utils.py
+++ b/model_utils.py
@@ -5,7 +5,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=None, auth_token=None, device_map=None, trust_remote_code=False):    
+def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=None, auth_token=None, device_map=None, trust_remote_code=False, return_token_type_ids=None):    
     if model_name.startswith('Salesforce/codegen'):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         if model_path is not None:
@@ -117,10 +117,10 @@ def get_local_huggingface_tokenizer_model(model_name, model_path=None, dtype=Non
             assert False
     elif model_path is not None and model_path != "":
         logger.warning("model_path is not None, but model_name is not given. Load from model_path only")
-        tokenizer = AutoTokenizer.from_pretrained(model_path, use_auth_token=auth_token)
+        tokenizer = AutoTokenizer.from_pretrained(model_path, use_auth_token=auth_token, return_token_type_ids=return_token_type_ids)
         model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float16, use_auth_token=auth_token, device_map=device_map, trust_remote_code=trust_remote_code)
     else:
-        tokenizer = AutoTokenizer.from_pretrained(model_name, use_auth_token=auth_token)
+        tokenizer = AutoTokenizer.from_pretrained(model_name, use_auth_token=auth_token, return_token_type_ids=return_token_type_ids)
         model = AutoModelForCausalLM.from_pretrained(model_name, use_auth_token=auth_token, device_map=device_map, trust_remote_code=trust_remote_code)
 
     if tokenizer.pad_token is None:

--- a/serving_local_nlp_model.py
+++ b/serving_local_nlp_model.py
@@ -115,6 +115,8 @@ class HuggingFaceLocalNLPModelInference(FastInferenceInterface):
             
             if max_memory == {}:
                 self.model = model.to(self.device)
+            else:
+                self.model = model
             
             if tokenizer.pad_token is None:
                 tokenizer.pad_token = tokenizer.eos_token

--- a/serving_local_nlp_model.py
+++ b/serving_local_nlp_model.py
@@ -63,6 +63,7 @@ class HuggingFaceLocalNLPModelInference(FastInferenceInterface):
         self.deny_list = args['deny_list']
         auth_token = args['auth_token']
         max_memory = args['max_memory']
+        trust_remote_code = args['trust_remote_code']
         
         if args.get('dtype') == 'llm.int8':
             model, tokenizer = get_local_huggingface_tokenizer_model_llm_int8(args['hf_model_name'], args['model_path'], None, auth_token=auth_token)
@@ -73,9 +74,6 @@ class HuggingFaceLocalNLPModelInference(FastInferenceInterface):
                 
             self.tokenizer = tokenizer
         else:
-            # Note: Falcon models require trust_remote_code=True. Rather than permanently enabling it for all models:
-            trust_remote_code=True if "falcon" in self.hf_model_name else False
-
             if max_memory != {}:
                 config = AutoConfig.from_pretrained(self.hf_model_name, trust_remote_code=trust_remote_code)
                 # load empty weights
@@ -380,6 +378,8 @@ if __name__ == "__main__":
                         help='plugin.')
     parser.add_argument('--auth-token', action='store_true',
                         help='indicates whether to get auth token from huggingface-cli. Used for private repos.')
+    parser.add_argument('--trust-remote-code', action='store_true',
+                        help='indicates whether to trust remote code from huggingface models')
     parser.add_argument(
         '-g',
         '--gpu-vram',
@@ -438,5 +438,6 @@ if __name__ == "__main__":
         "plugin": plugin,
         "auth_token": args.auth_token,
         "max_memory": max_memory,
+        "trust_remote_code": args.trust_remote_code,
     })
     fip.start()


### PR DESCRIPTION
This PR adds multi-card support similar to OpenChatKit. 

The `tiiuae/falcon-40b-instruct` model requires `trust_remote_code=True` for the model and config. I've set it to True only if 'falcon' is in the model name. Let me know if you have better ideas on how to handle this.

The `tiiuae/falcon-40b-instruct` model requires 160 GB VRAM. Will need to splitting the model across >2 xA100-80s rather than =2 to avoid CUDA OOM. You could also split it across all 8 GPUs if needed.

An example for the args to split this model across 4xA100-80  would be `-g 0:40 1:40 2:40 3:40`, which allocates a max of 40GiB to CUDA devices 0, 1, 2, and 3.

Setting max-allocated = max-vram-on-card will result in OOM.