### PR TITLE
Update Dockerfile to valid cuda image

### DIFF
--- a/dockerfile_together
+++ b/dockerfile_together
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 nvidia/cuda:11.3.0-cudnn8-devel-ubuntu20.04
+FROM --platform=linux/amd64 nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The existing CUDA docker image does not exist anymore. See this error: https://github.com/togethercomputer/Quick_Deployment_HELM/actions/runs/5511781368
Updated to an existing docker image