### PR TITLE
Fix return-token-type-id and add skip_special_tokens

### DIFF
--- a/model_utils.py
+++ b/model_utils.py
@@ -13,7 +13,6 @@ def get_local_huggingface_tokenizer_model(
         auth_token=None, 
         max_memory=None, 
         trust_remote_code=False, 
-        return_token_type_ids=None, 
         device=None
 ): 
     if max_memory != {}:
@@ -144,10 +143,10 @@ def get_local_huggingface_tokenizer_model(
             assert False
     elif model_path is not None and model_path != "":
         logger.warning("model_path is not None, but model_name is not given. Load from model_path only")
-        tokenizer = AutoTokenizer.from_pretrained(model_path, use_auth_token=auth_token, return_token_type_ids=return_token_type_ids, trust_remote_code=trust_remote_code)
+        tokenizer = AutoTokenizer.from_pretrained(model_path, use_auth_token=auth_token, trust_remote_code=trust_remote_code)
         model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.float16, use_auth_token=auth_token, device_map=device_map, trust_remote_code=trust_remote_code)
     else:
-        tokenizer = AutoTokenizer.from_pretrained(model_name, use_auth_token=auth_token, return_token_type_ids=return_token_type_ids, torch_dtype=dtype, trust_remote_code=trust_remote_code)
+        tokenizer = AutoTokenizer.from_pretrained(model_name, use_auth_token=auth_token, torch_dtype=dtype, trust_remote_code=trust_remote_code)
         model = AutoModelForCausalLM.from_pretrained(model_name, use_auth_token=auth_token, device_map=device_map, trust_remote_code=trust_remote_code, torch_dtype=dtype)
 
     if tokenizer.pad_token is None:

--- a/serving_local_nlp_model.py
+++ b/serving_local_nlp_model.py
@@ -8,6 +8,7 @@ import random
 import logging
 import argparse
 import numpy as np
+from functools import wraps
 from faiss_retrieval import *
 from utils import *
 from model_utils import *
@@ -63,7 +64,7 @@ class HuggingFaceLocalNLPModelInference(FastInferenceInterface):
         auth_token = args['auth_token']
         max_memory = args['max_memory']
         trust_remote_code = args['trust_remote_code']
-        self.return_token_type_ids = args['return_token_type_ids']
+        no_return_token_type_ids = args['no_return_token_type_ids']
         
         if args.get('dtype') == 'llm.int8':
             model, tokenizer = get_local_huggingface_tokenizer_model_llm_int8(args['hf_model_name'], args['model_path'], None, auth_token=auth_token)
@@ -81,16 +82,23 @@ class HuggingFaceLocalNLPModelInference(FastInferenceInterface):
                 auth_token=auth_token, 
                 max_memory=max_memory, 
                 trust_remote_code=trust_remote_code, 
-                return_token_type_ids=self.return_token_type_ids,
                 device=self.device,
             )
 
             self.model = model
             self.tokenizer = tokenizer
 
-        # fixes error on Falcon models
-        if self.return_token_type_ids is False:
-            self.tokenizer.return_token_type_ids = False
+        # fix for The following `model_kwargs` are not used by the model: ['token_type_ids'] 
+        # credit: https://huggingface.co/tiiuae/falcon-7b-instruct/discussions/2#6481fe4e9135a74ca541b310
+        if no_return_token_type_ids:
+            tok_call_one = self.tokenizer._call_one
+    
+            @wraps(tok_call_one)
+            def _call_one_wrapped(*x, **y):
+                y['return_token_type_ids'] = False
+                return tok_call_one(*x, **y)
+            
+            self.tokenizer._call_one = _call_one_wrapped
 
         self.plugin = args.get('plugin')
         torch.manual_seed(0)
@@ -434,6 +442,6 @@ if __name__ == "__main__":
         "auth_token": args.auth_token,
         "max_memory": max_memory,
         "trust_remote_code": args.trust_remote_code,
-        "return_token_type_ids": not args.no_return_token_type_ids,
+        "no_return_token_type_ids": args.no_return_token_type_ids,
     })
     fip.start()


### PR DESCRIPTION
- Return_token_type_id fix: Resolves `ValueError: The following 'model_kwargs' are not used by the model: ['token_type_ids']` error seen in all LLaMA-based models (vicuna, alpaca, falcon)
- `--skip-special-tokens` argument: Hides special tokens. Needed for NSQL model