### PR TITLE
Upgrade to cuda 11.7 image for flash-attn

### DIFF
--- a/dockerfile_together
+++ b/dockerfile_together
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
+FROM --platform=linux/amd64 nvidia/cuda:11.7.1-cudnn8-devel-ubuntu20.04
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
@@ -16,15 +16,13 @@ ENV PATH /home/user/.local/bin:$PATH
 ENV CUDA_HOME="/usr/local/cuda"
 
 RUN pip install --no-cache-dir --upgrade pip packaging && \
-    pip install --no-cache-dir cupy-cuda113 && \
-    pip install --no-cache-dir jaxlib==0.3.22+cuda113.cudnn820 -f https://alpa-projects.github.io/wheels.html && \
-    pip install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+    pip install --no-cache-dir cupy-cuda11x  && \
+    pip install --no-cache-dir torch torchvision torchaudio
 
 ENV LD_LIBRARY_PATH=${CUDA_HOME}/lib64/stubs:${LD_LIBRARY_PATH}
 
 RUN pip3 install --no-cache-dir \
       git+https://github.com/huggingface/accelerate.git@5b9c5881b687af1c7a8807aa20ac4a6b36f085c9 \
-      alpa \
       bitsandbytes==0.39.1 \
       einops \
       fastapi \


### PR DESCRIPTION
- Required by flash-attn 
- Removed alpa dependencies as discussed here: https://discord.com/channels/988968225930887198/1063104263967998002/1131309434140905523