### PR TITLE
Change transformers_port to fix_rotar_emb branch

### DIFF
--- a/dockerfile_together
+++ b/dockerfile_together
@@ -34,7 +34,7 @@ RUN pip3 install --no-cache-dir \
       git+https://github.com/huggingface/peft.git@b1bafca3332c7ff21dcb92892df38a04d3b43d56 \
       scipy \
       'llm_serving @ git+https://github.com/alpa-projects/alpa#subdirectory=examples' \
-      'transformers @ git+https://github.com/togethercomputer/transformers_port@fix_rotar_emb'
+      'transformers @ git+https://github.com/togethercomputer/transformers_port@v0.0.1'
 
 RUN MAX_JOBS=2 pip3 install pip install flash-attn --no-build-isolation --no-cache-dir
 RUN pip3 install git+https://github.com/HazyResearch/flash-attention.git#subdirectory=csrc/rotary

--- a/dockerfile_together
+++ b/dockerfile_together
@@ -34,7 +34,7 @@ RUN pip3 install --no-cache-dir \
       git+https://github.com/huggingface/peft.git@b1bafca3332c7ff21dcb92892df38a04d3b43d56 \
       scipy \
       'llm_serving @ git+https://github.com/alpa-projects/alpa#subdirectory=examples' \
-      'transformers @ git+https://github.com/togethercomputer/transformers_port@43a75627962c70db1f4b1272883aa34240531ca0'
+      'transformers @ git+https://github.com/togethercomputer/transformers_port@fix_rotar_emb'
 
 RUN MAX_JOBS=2 pip3 install pip install flash-attn --no-build-isolation --no-cache-dir
 RUN pip3 install git+https://github.com/HazyResearch/flash-attention.git#subdirectory=csrc/rotary


### PR DESCRIPTION
I made a [branch of transformers_port ](https://github.com/togethercomputer/transformers_port/tree/fix_rotar_emb) that fixes the rotary embedding problem.

I rebuilt the docker before and after the fix and confirmed it fixed the rotary emb problem. I had some permissions issues in docker with together-node so I was unable to verify fullly end to end.

Note: I'm not a fan of using specific branches or commits for package installations. Can we change transformers_port main, or use a release tag instead?