### PR TITLE
Avoid ChatML translation for non-ChatML prompts

### DIFF
--- a/serving_local_nlp_model.py
+++ b/serving_local_nlp_model.py
@@ -24,15 +24,15 @@ logger = logging.getLogger(__name__)
 logger.setLevel(int(os.environ.get('LOG_LEVEL', logging.DEBUG)))
 
 def translate_chatml_to_openchat(prompt):
-    prompt = prompt.replace('<|im_start|>system\n', '<human>: ')
-    prompt = prompt.replace('<|im_start|>user\n', '<human>: ')
-    prompt = prompt.replace('<|im_start|>assistant\n', '<bot>: ')
-    prompt = prompt.replace('<|im_start|>user', '<human>:')
-    prompt = prompt.replace('<|im_start|>assistant', '<bot>:')
-    prompt = prompt.replace('\n<|im_end|>', '')
-    prompt = prompt.replace('<|im_end|>', '')
-    prompt = prompt.rstrip()
-    # print(prompt)
+    if '<|im_start|>' in prompt:
+        prompt = prompt.replace('<|im_start|>system\n', '<human>: ')
+        prompt = prompt.replace('<|im_start|>user\n', '<human>: ')
+        prompt = prompt.replace('<|im_start|>assistant\n', '<bot>: ')
+        prompt = prompt.replace('<|im_start|>user', '<human>:')
+        prompt = prompt.replace('<|im_start|>assistant', '<bot>:')
+        prompt = prompt.replace('\n<|im_end|>', '')
+        prompt = prompt.replace('<|im_end|>', '')
+        prompt = prompt.rstrip()
     return prompt
 
 class HuggingFaceLocalNLPModelInference(FastInferenceInterface):


### PR DESCRIPTION
This PR tackles an issue in our current ChatML translation process where trailing spaces and newlines at the end of a prompt are removed due to the `rstrip()` function ([here](https://github.com/togethercomputer/Quick_Deployment_HELM/blob/1c82a4e808b5b655568136556e265913bbe4f647/serving_local_nlp_model.py#L34)). This behavior might not always be desired, especially for the Llama-2-32K-Instruct model that we are going to release.

In the previous implementation, the `rstrip()` function was called after ChatML translation, causing the elimination of any trailing spaces and newlines. This PR introduces a check for the presence of the `<|im_start|>` string in the prompt. The ChatML translation, and consequently the `rstrip()` function, will only be applied if the `<|im_start|>` string is found in the prompt.