### PR TITLE
Add QwenModel

### DIFF
--- a/qwen.py
+++ b/qwen.py
@@ -1,0 +1,16 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers.generation import GenerationConfig
+from together_worker.fast_inference import FastInferenceInterface
+
+class QwenModel(FastInferenceInterface):
+    def setup(self, args):
+        self.tokenizer = AutoTokenizer.from_pretrained(args.hf_model_name, trust_remote_code=True)
+        self.model = AutoModelForCausalLM.from_pretrained(args.hf_model_name, device_map="auto", trust_remote_code=True).eval()
+        self.model.generation_config = GenerationConfig.from_pretrained(args.hf_model_name, trust_remote_code=True) 
+        
+    def dispatch_request(self, args, env):
+        prompt = args[0]["prompt"]
+        response, history = self.model.chat(self.tokenizer, prompt, history=None)
+        return {
+            "choices": [ { "text": response } ],
+        }


### PR DESCRIPTION
For use with together-node config like:
```
worker:
  mode: docker-service
  image: togethercomputer/native_hf_models:latest
  model: Qwen/Qwen-7B-Chat
  service: togethercomputer/Qwen-7B-Chat
  group:
    alloc: each
  gpu:
    type: cuda
    alloc: each
    index: 0
  network:
    mode: host
  command: python3 -m together_worker.serving qwen QwenModel
  env: HF_HOME=/home/user/.together/models SERVICE_DOMAIN=together
```